### PR TITLE
Expose Player Loaded Property and Better Initial Loading View Layout

### DIFF
--- a/WKYTPlayerView/WKYTPlayerView.h
+++ b/WKYTPlayerView/WKYTPlayerView.h
@@ -153,6 +153,9 @@ typedef NS_ENUM(NSInteger, WKYTPlayerError) {
 /** A delegate to be notified on playback events. */
 @property(nonatomic, weak, nullable) id<WKYTPlayerViewDelegate> delegate;
 
+/** Indicates whether the Youtube iFrame has loaded or not */
+@property(nonatomic, assign) BOOL isPlayerLoaded;
+
 /**
  * This method loads the player with the given video ID.
  * This is a convenience method for calling WKYTPlayerView::loadPlayerWithVideoId:withPlayerVars:

--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -723,6 +723,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
         if (self.initialLoadingView) {
             [self.initialLoadingView removeFromSuperview];
         }
+		_isPlayerLoaded = true;
         if ([self.delegate respondsToSelector:@selector(playerViewDidBecomeReady:)]) {
             [self.delegate playerViewDidBecomeReady:self];
         }
@@ -778,7 +779,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
         if (self.initialLoadingView) {
             [self.initialLoadingView removeFromSuperview];
         }
-        
+		_isPlayerLoaded = false;
         if ([self.delegate respondsToSelector:@selector(playerViewIframeAPIDidFailedToLoad:)]) {
             [self.delegate playerViewIframeAPIDidFailedToLoad:self];
         }
@@ -855,6 +856,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
  * @return YES if successful, NO if not.
  */
 - (BOOL)loadWithPlayerParams:(NSDictionary *)additionalPlayerParams {
+	_isPlayerLoaded = false;
     NSDictionary *playerCallbacks = @{
                                       @"onReady" : @"onReady",
                                       @"onStateChange" : @"onStateChange",
@@ -975,8 +977,38 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
         UIView *initialLoadingView = [self.delegate playerViewPreferredInitialLoadingView:self];
         if (initialLoadingView) {
             initialLoadingView.frame = self.bounds;
-            initialLoadingView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+			initialLoadingView.translatesAutoresizingMaskIntoConstraints = NO;
             [self addSubview:initialLoadingView];
+			NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:initialLoadingView
+																			 attribute:NSLayoutAttributeTop
+																			 relatedBy:NSLayoutRelationEqual
+																				toItem:self
+																			 attribute:NSLayoutAttributeTop
+																			multiplier:1.0
+																			  constant:0.0];
+			NSLayoutConstraint *leftConstraint = [NSLayoutConstraint constraintWithItem:initialLoadingView
+																			  attribute:NSLayoutAttributeLeft
+																			  relatedBy:NSLayoutRelationEqual
+																				 toItem:self
+																			  attribute:NSLayoutAttributeLeft
+																			 multiplier:1.0
+																			   constant:0.0];
+			NSLayoutConstraint *rightConstraint = [NSLayoutConstraint constraintWithItem:initialLoadingView
+																			   attribute:NSLayoutAttributeRight
+																			   relatedBy:NSLayoutRelationEqual
+																				  toItem:self
+																			   attribute:NSLayoutAttributeRight
+																			  multiplier:1.0
+																				constant:0.0];
+			NSLayoutConstraint *bottomConstraint = [NSLayoutConstraint constraintWithItem:initialLoadingView
+																				attribute:NSLayoutAttributeBottom
+																				relatedBy:NSLayoutRelationEqual
+																				   toItem:self
+																				attribute:NSLayoutAttributeBottom
+																			   multiplier:1.0
+																				 constant:0.0];
+			NSArray *constraints = @[topConstraint, leftConstraint, rightConstraint, bottomConstraint];
+			[self addConstraints:constraints];
             self.initialLoadingView = initialLoadingView;
         }
     }


### PR DESCRIPTION
Exposes a boolean `isPlayerLoaded` property that allows callers to check if the player is loaded without having to rely on the delegate callback.

Also, updates the layout code for the initial loading view so that it properly fills the player view area.