### PR TITLE
Adds an error view that callers can set to show if the youtube player fails to load

### DIFF
--- a/WKYTPlayerView/WKYTPlayerView.h
+++ b/WKYTPlayerView/WKYTPlayerView.h
@@ -131,6 +131,20 @@ typedef NS_ENUM(NSInteger, WKYTPlayerError) {
 - (nullable UIView *)playerViewPreferredInitialLoadingView:(nonnull WKYTPlayerView *)playerView;
 
 /**
+ * Callback invoked when initially loading the Youtube iframe to the webview to display a custom
+ * error view when the player iframe has failed to load. The error view will be shown just before
+ * the playerViewIframeAPIDidFailedToLoad: callback is invoked.
+ *
+ * The default implementation does not display any custom error views so the player will display
+ * a blank view with a background color of (-playerViewPreferredWebViewBackgroundColor:).
+ *
+ * @param playerView The WKYTPlayerView instance where the error view will be used.
+ * @return A view object that will be displayed when YouTube iframe API failed to load.
+ *         Pass nil to display no custom loading view. Default implementation returns nil.
+ */
+- (nullable UIView *)playerViewPreferredErrorView:(nonnull WKYTPlayerView *)playerView;
+
+/**
  * Callback invoked when an api loading error has occured.
  *
  * @param playerView The WKYTPlayerView instance where the error has occurred.
@@ -152,9 +166,6 @@ typedef NS_ENUM(NSInteger, WKYTPlayerError) {
 
 /** A delegate to be notified on playback events. */
 @property(nonatomic, weak, nullable) id<WKYTPlayerViewDelegate> delegate;
-
-/** Indicates whether the Youtube iFrame has loaded or not */
-@property(nonatomic, assign) BOOL isPlayerLoaded;
 
 /**
  * This method loads the player with the given video ID.

--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -857,7 +857,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
 
 - (void)showErrorView {
 	if (!self.errorView) {
-		return
+		return;
 	}
 	
 	if (self.errorView.superview) {
@@ -1068,6 +1068,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
 			if (errorView) {
 				self.errorView = errorView;
 			}
+		}
     }
     
     return YES;

--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -66,7 +66,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
 
 @property (nonatomic, strong) NSURL *originURL;
 @property (nonatomic, weak) UIView *initialLoadingView;
-@property (nonatomic, weak) UIView *errorView;
+@property (nonatomic, strong) UIView *errorView;
 
 @end
 
@@ -782,6 +782,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
         if (self.initialLoadingView) {
             [self.initialLoadingView removeFromSuperview];
         }
+		
 		if (self.errorView) {
 			[self showErrorView];
 		}

--- a/WKYTPlayerView/WKYTPlayerView.m
+++ b/WKYTPlayerView/WKYTPlayerView.m
@@ -66,6 +66,7 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
 
 @property (nonatomic, strong) NSURL *originURL;
 @property (nonatomic, weak) UIView *initialLoadingView;
+@property (nonatomic, weak) UIView *errorView;
 
 @end
 
@@ -723,7 +724,9 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
         if (self.initialLoadingView) {
             [self.initialLoadingView removeFromSuperview];
         }
-		_isPlayerLoaded = true;
+		if (self.errorView.superview) {
+			[self.errorView removeFromSuperview];
+		}
         if ([self.delegate respondsToSelector:@selector(playerViewDidBecomeReady:)]) {
             [self.delegate playerViewDidBecomeReady:self];
         }
@@ -779,7 +782,9 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
         if (self.initialLoadingView) {
             [self.initialLoadingView removeFromSuperview];
         }
-		_isPlayerLoaded = false;
+		if (self.errorView) {
+			[self showErrorView];
+		}
         if ([self.delegate respondsToSelector:@selector(playerViewIframeAPIDidFailedToLoad:)]) {
             [self.delegate playerViewIframeAPIDidFailedToLoad:self];
         }
@@ -846,6 +851,53 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
     }
 }
 
+/**
+ * Adds the custom error view to the view hierarchy if it has been set previously.
+ */
+
+- (void)showErrorView {
+	if (!self.errorView) {
+		return
+	}
+	
+	if (self.errorView.superview) {
+		[self.errorView removeFromSuperview];
+	}
+	
+	self.errorView.frame = self.bounds;
+	self.errorView.translatesAutoresizingMaskIntoConstraints = NO;
+	[self addSubview:self.errorView];
+	NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:self.errorView
+																	 attribute:NSLayoutAttributeTop
+																	 relatedBy:NSLayoutRelationEqual
+																		toItem:self
+																	 attribute:NSLayoutAttributeTop
+																	multiplier:1.0
+																	  constant:0.0];
+	NSLayoutConstraint *leftConstraint = [NSLayoutConstraint constraintWithItem:self.errorView
+																	  attribute:NSLayoutAttributeLeft
+																	  relatedBy:NSLayoutRelationEqual
+																		 toItem:self
+																	  attribute:NSLayoutAttributeLeft
+																	 multiplier:1.0
+																	   constant:0.0];
+	NSLayoutConstraint *rightConstraint = [NSLayoutConstraint constraintWithItem:self.errorView
+																	   attribute:NSLayoutAttributeRight
+																	   relatedBy:NSLayoutRelationEqual
+																		  toItem:self
+																	   attribute:NSLayoutAttributeRight
+																	  multiplier:1.0
+																		constant:0.0];
+	NSLayoutConstraint *bottomConstraint = [NSLayoutConstraint constraintWithItem:self.errorView
+																		attribute:NSLayoutAttributeBottom
+																		relatedBy:NSLayoutRelationEqual
+																		   toItem:self
+																		attribute:NSLayoutAttributeBottom
+																	   multiplier:1.0
+																		 constant:0.0];
+	NSArray *constraints = @[topConstraint, leftConstraint, rightConstraint, bottomConstraint];
+	[self addConstraints:constraints];
+}
 
 /**
  * Private helper method to load an iframe player with the given player parameters.
@@ -856,7 +908,6 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
  * @return YES if successful, NO if not.
  */
 - (BOOL)loadWithPlayerParams:(NSDictionary *)additionalPlayerParams {
-	_isPlayerLoaded = false;
     NSDictionary *playerCallbacks = @{
                                       @"onReady" : @"onReady",
                                       @"onStateChange" : @"onStateChange",
@@ -1011,6 +1062,12 @@ NSString static *const kWKYTPlayerSyndicationRegexPattern = @"^https://tpc.googl
 			[self addConstraints:constraints];
             self.initialLoadingView = initialLoadingView;
         }
+		
+		if ([self.delegate respondsToSelector:@selector(playerViewPreferredErrorView:)]) {
+			UIView *errorView = [self.delegate playerViewPreferredErrorView:self];
+			if (errorView) {
+				self.errorView = errorView;
+			}
     }
     
     return YES;


### PR DESCRIPTION
Adds a delegate method that asks the delegate for a view that will be displayed when the youtube iframe fails to load. Also removes the previously exposed isPlayerLoaded property which is now no longer needed to be exposed.